### PR TITLE
Removal of Attach User

### DIFF
--- a/server/src/services/users/users.hooks.js
+++ b/server/src/services/users/users.hooks.js
@@ -9,7 +9,7 @@ module.exports = {
     before: {
         all: [],
         find: [authenticate('jwt'),
-            attachUser(),
+            // attachUser(),
             roleBasedRestrictions(['Coordinator'])
         ],
         get: [authenticate('jwt')],


### PR DESCRIPTION
Originally I created this code to attach the user to the request (at first I didn't know it was being attached by feathers/authentication since request.params.user) is only present when it is on JWT request.