### PR TITLE
Hotfix for passing props through read-only access

### DIFF
--- a/client/components/reviewer/ReviewerEOCModal.js
+++ b/client/components/reviewer/ReviewerEOCModal.js
@@ -208,7 +208,7 @@ const ViewModal = ({
                                 documents={course?.documents}
                                 eocBeingViewed={eocGeneralAndSpecific}
                                 isReviewer
-                                isReadOnly
+                                isReadOnly={isReadOnly}
                             />
                         </GridItem>
                     </GridItem>


### PR DESCRIPTION
This closes #93.

I have already applied this as a hotfix in the current deployment.