### PR TITLE
I48 pagination defaults

### DIFF
--- a/mkdocs/docs/changelog.md
+++ b/mkdocs/docs/changelog.md
@@ -3,7 +3,7 @@ This is the changelog for IndEAA.
 
 # v1.2.0 - Jul 15, 2021
 ???+ success "New"
-    - Implemented Cypress and Automated Testing Pipeline ([#48](https://github.com/uwasystemhealth/IndEAA/issues/48))
+    - Implemented Cypress and Automated Testing Pipeline ([#14](https://github.com/uwasystemhealth/IndEAA/issues/14))
   
 ???+ info "Improvements"
     - Pagination Default Changes from 20 to 100 ([#48](https://github.com/uwasystemhealth/IndEAA/issues/48))

--- a/mkdocs/docs/changelog.md
+++ b/mkdocs/docs/changelog.md
@@ -1,13 +1,17 @@
 # Changelog
 This is the changelog for IndEAA.
 
-# v1.1.1 "Config Hotfix" - Jul 15, 2021
+# v1.2.0 - Jul 15, 2021
 ???+ info "Improvements"
     - Pagination Default Changes from 20 to 100 ([#48](https://github.com/uwasystemhealth/IndEAA/issues/48))
+    - Cleanups of Import (partial progress) ([#42](https://github.com/uwasystemhealth/IndEAA/issues/42))
+
+???+ bug "Bugfixes"
+    - Broken css documentation fix ([#125](https://github.com/uwasystemhealth/IndEAA/issues/125))
 
 # v1.1.0 - Mar 3, 2021
 ???+ info "Improvements"
-    - Introduction Documents + Some Optimisation of Data Fetching Optimisation Related ([#82](https://github.com/uwasystemhealth/IndEAA/issues/82), [#108](https://github.com/uwasystemhealth/IndEAA/issues/108) )
+    - Introduction Documents + Some Optimisation o f Data Fetching Optimisation Related ([#82](https://github.com/uwasystemhealth/IndEAA/issues/82), [#108](https://github.com/uwasystemhealth/IndEAA/issues/108) )
     - Permission protection + metadata on course-evaluation page ([#24](https://github.com/uwasystemhealth/IndEAA/issues/24), [#71](https://github.com/uwasystemhealth/IndEAA/issues/71))
 
 ???+ bug "Bugfixes"

--- a/mkdocs/docs/changelog.md
+++ b/mkdocs/docs/changelog.md
@@ -2,6 +2,9 @@
 This is the changelog for IndEAA.
 
 # v1.2.0 - Jul 15, 2021
+???+ success "New"
+    - Implemented Cypress and Automated Testing Pipeline ([#48](https://github.com/uwasystemhealth/IndEAA/issues/48))
+  
 ???+ info "Improvements"
     - Pagination Default Changes from 20 to 100 ([#48](https://github.com/uwasystemhealth/IndEAA/issues/48))
     - Cleanups of Import (partial progress) ([#42](https://github.com/uwasystemhealth/IndEAA/issues/42))

--- a/mkdocs/docs/changelog.md
+++ b/mkdocs/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 This is the changelog for IndEAA.
 
+# v1.1.1 "Config Hotfix" - Jul 15, 2021
+???+ info "Improvements"
+    - Pagination Default Changes from 20 to 100 ([#48](https://github.com/uwasystemhealth/IndEAA/issues/48))
+
 # v1.1.0 - Mar 3, 2021
 ???+ info "Improvements"
     - Introduction Documents + Some Optimisation of Data Fetching Optimisation Related ([#82](https://github.com/uwasystemhealth/IndEAA/issues/82), [#108](https://github.com/uwasystemhealth/IndEAA/issues/108) )

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -3,8 +3,8 @@
   "port": 3030,
   "public": "../public/",
   "paginate": {
-    "default": 20,
-    "max": 50
+    "default": 100,
+    "max": 500
   },
   "authentication": {
     "entity": "user",


### PR DESCRIPTION
## General Information
As per mentioned in #48 , in production you can only see 20 users at a time which is problematic. This postpones the issue of #48. This means that the system will still be useful until 100 records (until we need to implement proper pagination).

Includes:
- pagination default change
- changelog

## Other Information
@uwasystemhealth/redbacks  this will probably be the last pull request, then we will release IndEAA v1.2.0 (as per the changelog) hopefully tomorrow.